### PR TITLE
Add import logs table migration

### DIFF
--- a/server/migrations/20250925_add_import_logs_table.sql
+++ b/server/migrations/20250925_add_import_logs_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS import_logs (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT now(),
+    origin TEXT,
+    filename TEXT,
+    status TEXT,
+    report_number TEXT,
+    error_message TEXT,
+    processing_ms INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS import_logs_status_idx ON import_logs (status);
+CREATE INDEX IF NOT EXISTS import_logs_created_at_idx ON import_logs (created_at DESC);


### PR DESCRIPTION
## Summary
- add migration to create the import_logs table used for tracking import attempts
- include supporting indexes on status and created_at to aid admin queries

## Testing
- npm run check *(fails: existing Manus analysis TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b26de1a88325a2015084c3fb8f3a